### PR TITLE
sensors: availability topics

### DIFF
--- a/src/can2mqtt/can2mqtt.py
+++ b/src/can2mqtt/can2mqtt.py
@@ -501,7 +501,7 @@ async def firmware_upload(
 
 async def mqtt_reader(mqtt_client, can_network, mqtt_topic_prefix):
     NODE_CMD = re.compile(
-        f"{mqtt_topic_prefix}/node_cmd_([0-9a-f]{{3}})/(nmt|firmware|write|update)(/.*)?$"
+        f"{mqtt_topic_prefix}/can_([0-9a-f]{{3}})/(update|nmt|node)/cmd/(write|firmware_file|firmware_raw)(/.*)?$"
     )
     async with mqtt_client.messages() as messages:
         await mqtt_client.subscribe(f"{mqtt_topic_prefix}/#")
@@ -561,11 +561,11 @@ async def mqtt_reader(mqtt_client, can_network, mqtt_topic_prefix):
             else:
                 m = NODE_CMD.match(message.topic.value)
                 match m and m.groups():
-                    case (node_id, "nmt", _):
+                    case (node_id, "nmt", "write", _):
                         cmd = int(message.payload.decode("utf-8"))
                         logger.info("sent nmt command %d to node %s", cmd, node_id)
                         can_network.send_message(0, [cmd, int(node_id, 16)])
-                    case (node_id, "update", arg):
+                    case (node_id, "update", "firmware_file", arg):
                         flags = int(arg[1:])
                         compress = bool(flags & 1)
                         node_id = int(node_id, 16)
@@ -589,7 +589,7 @@ async def mqtt_reader(mqtt_client, can_network, mqtt_topic_prefix):
                                     compress,
                                 )
                             )
-                    case (node_id, "firmware", arg):
+                    case (node_id, "update", "firmware_raw", arg):
                         flags = int(arg[1:])
                         compress = bool(flags & 1)
                         asyncio.create_task(
@@ -597,7 +597,7 @@ async def mqtt_reader(mqtt_client, can_network, mqtt_topic_prefix):
                                 can_network, int(node_id, 16), message.payload, compress
                             )
                         )
-                    case (node_id, "write", arg):
+                    case (node_id, "node", "write", arg):
                         arg = arg[1:]
                         try:
                             node_id = int(node_id, 16)

--- a/src/can2mqtt/can2mqtt.py
+++ b/src/can2mqtt/can2mqtt.py
@@ -125,11 +125,7 @@ def get_tptd_cb(mqtt_client):
             entity = StateMixin.get_entity_by_node_state_key(node_id, key)
             if entity:
                 try:
-                    state_topic, value = entity.get_mqtt_state(key, await v.aget_raw())
-                    await mqtt_client.publish(state_topic, payload=value, retain=False)
-                    logger.debug(
-                        "MQTT publish topic: %s value: %s - ok", state_topic, value
-                    )
+                    await entity.publish_mqtt_state(mqtt_client, key, await v.aget_raw())
                 except ValueError as e:
                     logger.error("%s", e)
             else:

--- a/src/can2mqtt/entities.py
+++ b/src/can2mqtt/entities.py
@@ -97,7 +97,7 @@ class StateMixin:
         return config
 
     def get_mqtt_state_topic(self, state_key):
-        return f"{self.mqtt_topic_prefix}/can_state_{self.node.id:03x}_{state_key:08x}"
+        return f"{self.mqtt_topic_prefix}/can_{self.node.id:03x}/{state_key:08x}/state"
 
     def get_mqtt_state(self, state_key, value):
         index = self.state_map.index(state_key)
@@ -156,7 +156,7 @@ class CommandMixin:
         return config
 
     def get_mqtt_command_topic(self, cmd_key):
-        return f"{self.mqtt_topic_prefix}/can_cmd_{self.node.id:03x}_{cmd_key:08x}"
+        return f"{self.mqtt_topic_prefix}/can_{self.node.id:03x}/{cmd_key:08x}/cmd"
 
     def get_can_cmd(self, topic, value):
         cmd_key = self._topic2cmdkey and self._topic2cmdkey.get(topic)
@@ -199,8 +199,14 @@ class Entity:
         self.mqtt_topic_prefix = mqtt_topic_prefix
         self.caps = caps
 
-        # TODO: add some canbus id part to allow for many can busses
-        self.unique_id = f"can_{self.node.id:03x}_{self.entity_index:02x}"
+        # TODO: Consider a more robust approach.
+        # Keep unique_id legacy-compatible when topic_prefix is "homeassistant".
+        # Only prepend topic_prefix if it differs from the default value.
+        if self.mqtt_topic_prefix == "homeassistant":
+            self.unique_id = f"can_{self.node.id:03x}_{self.entity_index:02x}"
+        else:
+            self.unique_id = f"{self.mqtt_topic_prefix}_can_{self.node.id:03x}_{self.entity_index:02x}"
+        self.config_path = f"{self.mqtt_topic_prefix}_can_{self.node.id:03x}/{self.entity_index:02x}"
         self.props = {}
         self._entities[self.unique_id] = self
 
@@ -233,7 +239,8 @@ class Entity:
         self.props[key] = value
 
     def get_mqtt_config_topic(self):
-        return f"{self.mqtt_topic_prefix}/{self.TYPE_NAME}/{self.unique_id}/config"
+        # TODO: make the configuration prefix configurable
+        return f"homeassistant/{self.TYPE_NAME}/{self.config_path}/config"
 
     def get_mqtt_config(self):
         cfg = {
@@ -329,14 +336,14 @@ class Update(Entity):
     flags = 0
 
     def get_state_topic(self):
-        return f"{self.mqtt_topic_prefix}/node_state_{self.node.id:03x}/update"
+        return f"{self.mqtt_topic_prefix}/can_{self.node.id:03x}/update/state"
 
     def get_json_attributes_topic(self):
-        return f"{self.mqtt_topic_prefix}/node_json_attr_{self.node.id:03x}/update"
+        return f"{self.mqtt_topic_prefix}/can_{self.node.id:03x}/update/attributes"
 
     def get_command_topic(self):
         return (
-            f"{self.mqtt_topic_prefix}/node_cmd_{self.node.id:03x}/update/{self.flags}"
+            f"{self.mqtt_topic_prefix}/can_{self.node.id:03x}/update/cmd/firmware_file/{self.flags}"
         )
 
     def get_mqtt_config(self):
@@ -390,7 +397,7 @@ class NMTStateSensor(Entity):
     ]
 
     def get_state_topic(self):
-        return f"{self.mqtt_topic_prefix}/can_state_{self.node.id:03x}_nmt_state"
+        return f"{self.mqtt_topic_prefix}/can_{self.node.id:03x}/nmt/state"
 
     def get_mqtt_config(self):
         config = super().get_mqtt_config()

--- a/src/can2mqtt/entities.py
+++ b/src/can2mqtt/entities.py
@@ -99,9 +99,14 @@ class StateMixin:
     def get_mqtt_state_topic(self, state_key):
         return f"{self.mqtt_topic_prefix}/can_{self.node.id:03x}/{state_key:08x}/state"
 
-    def get_mqtt_state(self, state_key, value):
+    async def publish_mqtt_state(self, mqtt_client, state_key, value):
+        state_topic = self.get_mqtt_state_topic(state_key)
         index = self.state_map.index(state_key)
-        return self.get_mqtt_state_topic(state_key), self.STATES[index][1](value)
+        value = self.STATES[index][1](value)
+        await mqtt_client.publish(state_topic, payload=value, retain=False)
+        logger.debug(
+            "MQTT publish topic: %s value: %s - ok", state_topic, value
+        )
 
     def setup_object_dictionary(self, node, base_index):
         super().setup_object_dictionary(node, base_index)
@@ -119,8 +124,7 @@ class StateMixin:
             value = await self.node.sdo[state_key >> 16][
                 (state_key >> 8) & 0xFF
             ].aget_raw()
-            topic, mqtt_value = self.get_mqtt_state(state_key, value)
-            await mqtt_client.publish(topic, mqtt_value, retain=False)
+            await self.publish_mqtt_state(mqtt_client, state_key, value)
 
 
 class CommandMixin:
@@ -449,14 +453,14 @@ class MinMaxValueMixin:
         v.data_type = datatypes.REAL32
         node.object_dictionary[base_index].add_member(v)
 
-    def get_mqtt_state(self, state_key, value):
+    async def publish_mqtt_state(self, mqtt_client, state_key, value):
         if value == self.N_LEVELS:
             value2 = math.nan
         else:
             min_val = self.props.get("min_value", 0)
             max_val = self.props.get("max_value", self.N_LEVELS - 1)
             value2 = scale_from_wire(value, min_val, max_val, self.N_LEVELS)
-        return super().get_mqtt_state(state_key, value2)
+        return super().publish_mqtt_state(mqtt_client, state_key, value2)
 
     # TODO: add scaling for commands in get_can_cmd
 

--- a/src/can2mqtt/entities.py
+++ b/src/can2mqtt/entities.py
@@ -418,8 +418,83 @@ class Sensor(StateMixin, Entity):
     TYPE_ID = 1
     TYPE_NAME = "sensor"
 
+    _availability_map = {}
+
+    def availability(self):
+        yield "availability", self.validate_state_default
+
+    @cached_property
+    def AVAILABILITY(self):
+        return list(self.availability())
+
     def states(self):
         yield "state_topic", float_to_str, datatypes.REAL32
+
+    def get_mqtt_config(self):
+        config = super(Sensor, self).get_mqtt_config()
+        assert len(self.AVAILABILITY) == len(self.state_map)
+        for (topic, *_), state_key in zip(self.AVAILABILITY, self.state_map):
+            config[topic].append({"topic": self.get_mqtt_state_availability_topic(state_key)})
+        return config
+
+    def get_mqtt_state_availability_topic(self, state_key):
+        return f"{self.mqtt_topic_prefix}/can_{self.node.id:03x}/{state_key:08x}/availability"
+
+    async def publish_mqtt_state_availability(self, mqtt_client, state_key, value):
+        """Publishes the availability status of a specific state to MQTT.
+
+        This method determines the availability (online/offline) based on a
+        validator defined in the AVAILABILITY list. To reduce network traffic,
+        it only publishes to the broker if the availability status has changed
+        since the last check.
+
+        Args:
+            mqtt_client: The MQTT client instance used for publishing.
+            state_key (str): The key identifying the state in state_map.
+            value: The current raw value of the state to be validated.
+
+        Returns:
+            None
+
+        Note:
+            The availability status is stored in the internal `_availability_map`
+            to track state changes across calls.
+        """
+        state_availability_topic = self.get_mqtt_state_availability_topic(state_key)
+        index = self.state_map.index(state_key)
+        is_valid = self.AVAILABILITY[index][1](state_key, value)
+        if state_key not in self._availability_map or is_valid != self._availability_map[state_key]:
+            self._availability_map[state_key] = is_valid
+            payload = "online" if is_valid else "offline"
+            await mqtt_client.publish(state_availability_topic, payload=payload, retain=False)
+            logger.debug(
+                "MQTT publish topic: %s value: %s - ok", state_availability_topic, value
+            )
+
+    def validate_state_default(self, state_key, value):
+        """Validates the sensor state using the default implementation.
+
+        This method checks if the value, after being processed by
+        the type-specific parser defined in STATES[][1], results in
+        a non-empty string or a truthy value.
+
+        Child classes should define their own parsers if this default
+        behavior is not desired.
+
+        Args:
+            state_key: The key identifying the state to validate.
+            value: The raw value to be validated.
+
+        Returns:
+            True if the value is valid (non-empty), False otherwise.
+        """
+        index = self.state_map.index(state_key)
+        value = self.STATES[index][1](value)
+        return bool(value)
+
+    async def publish_mqtt_state(self, mqtt_client, state_key, value):
+        await self.publish_mqtt_state_availability(mqtt_client, state_key, value)
+        return await super(Sensor, self).publish_mqtt_state(mqtt_client, state_key, value)
 
     def canopen_metadata_properties(self):
         yield from super().canopen_metadata_properties()
@@ -427,6 +502,7 @@ class Sensor(StateMixin, Entity):
         yield 4, "state_class"
 
     def setup_object_dictionary(self, node: RemoteNode, base_index):
+        self._availability_map.clear()
         super().setup_object_dictionary(node, base_index)
         logger.info("sensor, setup od")
         node.object_dictionary[base_index].add_member(

--- a/src/can2mqtt/entities.py
+++ b/src/can2mqtt/entities.py
@@ -418,7 +418,9 @@ class Sensor(StateMixin, Entity):
     TYPE_ID = 1
     TYPE_NAME = "sensor"
 
-    _availability_map = {}
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._availability_map = {}
 
     def availability(self):
         yield "availability", self.validate_state_default


### PR DESCRIPTION
HA ignores all state updates with empty content. This way, when sensor reports NaN the value in HA gets stucked in the last known value and makes the user unaware of malfunctioning sensor.

Other changes:
- cleanup of MQTT topic tree
- possibility to run more than one can2mqtt instance with a  single MQTT server